### PR TITLE
Add configuration for json utf characters handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ Controls whether or not `<Leader>tt` will run the HTTP client. Regardless of the
 
 Sets the vim filetype when vim-http-client detects a JSON response. Though JSON-specific syntax highlighting like [vim-json](https://github.com/elzr/vim-json) provides prettier highlighting than the default Javascript highlighting, Javascript highlighting comes with Vim and is therefore a safer default. Use this setting to configure the filetype to your liking.
 
+#### g:http_client_json_escape_utf (default 1)
+
+By default json.dumps will escape any utf8 characters beyond ascii range. This option (if set to 0) allows you to get the actual special characters instead of \uxxxx encoded ones.
+
+
 ## Contributing
 
 This plugin is currently quite simple. Contributions, suggestions, and feedback are all welcomed!

--- a/doc/http-client.txt
+++ b/doc/http-client.txt
@@ -91,6 +91,7 @@ all others will get ft=text.
 Configuration                                        *http-client-configuration*
                                                      *g:http_client_bind_hotkey*
                                                          *g:http_client_json_ft*
+                                                 *g:http_client_json_escape_utf*
 
 g:http_client_bind_hotkey (default 1)
 
@@ -103,6 +104,12 @@ JSON-specific syntax highlighting provides prettier highlighting than the
 default Javascript highlighting, Javascript highlighting comes with Vim and is
 therefore a safer default. Use this setting to configure the filetype to your
 liking.
+
+g:http_client_json_escape_utf (default 1)
+
+By default json.dumps will escape any utf8 characters beyond ascii range. This
+option (if set to 0) allows you to get the actual special characters instead
+of \uxxxx encoded ones.
 
 ==============================================================================
 Installation                                          *http-client-installation*

--- a/plugin/http_client.py
+++ b/plugin/http_client.py
@@ -81,8 +81,10 @@ def do_request(block, buf):
     response_body = response.text
     if content_type == 'application/json':
         try:
-            response_body = json.dumps(json.loads(response.text), sort_keys=True,
-                    indent=2, separators=(',', ': '))
+            response_body = json.dumps(
+                json.loads(response.text), sort_keys=True, indent=2,
+                separators=(',', ': '),
+                ensure_ascii=vim.eval('g:http_client_json_escape_utf')=='1')
         except ValueError:
             pass
 

--- a/plugin/http_client.vim
+++ b/plugin/http_client.vim
@@ -9,6 +9,10 @@ if !exists('http_client_json_ft')
   let g:http_client_json_ft = 'javascript'
 endif
 
+if !exists('http_client_json_escape_utf')
+  let g:http_client_json_escape_utf = 1
+endif
+
 function! s:DoHTTPRequest()
   if !has('python')
     echo 'Error: this plugin requires vim compiled with python support.'


### PR DESCRIPTION
The default pythons json.dumps behavior escapes any special utf8
characters, leaving \uxxxx encoded strings as the output. 

It would be great to allow configuration of that feature, especially since it only requires a boolean flag to be passed to dumps call.
