### PR TITLE
Repeat the last request function and binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Once you have these, use your favorite Vim plugin manager to install `aquach/vim
 
 Put your cursor anywhere in a newline-delimited block of text and hit `<Leader>tt`. `vim-http-client` will parse the text into a HTTP request, execute it, and display its results will appear in a split. You can also directly invoke the HTTP client with `:call HTTPClientDoRequest()<cr>`. The format mirrors HTTP's format:
 
+
 ```
 # Comments start with #.
 # First request.
@@ -85,6 +86,7 @@ bar=!file(/tmp/my_file.txt)
 baz=!content(sample content)
 ```
 
+You can also recall the last request by `<Leader>tr`. This works from anywhere, since the request parameters are saved in a global vim variable `g:http_client_last_request`. It's also possible to call the command directly as :call HTTPClientRepeatRequest()<cr>. Of course this only works after at least one call.
 
 
 See `examples/examples.txt` for more examples.

--- a/doc/http-client.txt
+++ b/doc/http-client.txt
@@ -81,6 +81,12 @@ If you'd like to pass form-encoded data, set your body like this: >
     ...
     <key-n>=<value-n>
 
+You can also recall the last request by `<Leader>tr`. This works from
+anywhere, since the request parameters are saved in a global vim variable
+`g:http_client_last_request`. It's also possible to call the command directly
+as :call HTTPClientRepeatRequest()<cr>. Of course this only works after at
+least one call.
+
 See `examples/examples.txt` for more examples.
 
 The output appears in a new split. Syntax highlighting is interpreted from the

--- a/plugin/http_client.vim
+++ b/plugin/http_client.vim
@@ -33,6 +33,28 @@ endfunction
 
 command! -nargs=0 HTTPClientDoRequest call <SID>DoHTTPRequest()
 
+function! s:DoLastHTTPRequest()
+  if !has('python')
+    echo 'Error: this plugin requires vim compiled with python support.'
+    finish
+  endif
+
+  if !exists('g:http_client_last_request')
+    echo 'There was no earlier http request recorded yet.'
+    finish
+  endif
+
+  if !s:initialized_client
+    let s:initialized_client = 1
+    execute 'pyfile ' . s:script_path . '/http_client.py'
+  endif
+
+  python repeat_last_request()
+endfunction
+
+command! -nargs=0 HTTPClientRepeatRequest call <SID>DoLastHTTPRequest()
+
 if g:http_client_bind_hotkey
   silent! nnoremap <unique> <Leader>tt :HTTPClientDoRequest<cr>
+  silent! nnoremap <unique> <Leader>tr :HTTPClientRepeatRequest<cr>
 endif


### PR DESCRIPTION
Sometimes, when debugging one specific endpoint, it's useful to just 'refresh' the result.

How about remembering the last made request and being able to call it again from anywhere (like from the output preview buffer, that has just stolen the focus :)
