### PR TITLE
Allow configuration to disable SSL verification in requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ By default the request result appears in a vertical split. Setting this option t
 
 By default the focus will go to the output window. If set to 0 the focus will return to the window with request definitions.
 
+#### g:http_client_verify_ssl (default 1)
+
+By default requests will verify SSL certificates for HTTPS endpoints. Setting this option to 0 disables SSL verification which allows requests to sites using self-signed certificates, for example.
 
 ## Contributing
 

--- a/doc/http-client.txt
+++ b/doc/http-client.txt
@@ -93,6 +93,7 @@ Configuration                                        *http-client-configuration*
                                                          *g:http_client_json_ft*
                                                  *g:http_client_json_escape_utf*
                                                    *g:http_client_result_vsplit*
+                                                   *g:http_client_verify_ssl*
 
 g:http_client_bind_hotkey (default 1)
 
@@ -121,6 +122,12 @@ g:http_client_focus_output_window (default 1)
 
 By default the focus will go to the output window. If set to 0 the focus will
 return to the window with request definitions.
+
+g:http_client_verify_ssl (default 1)
+
+By default requests will verify SSL certificates for HTTPS endpoints. Setting
+this option to 0 disables SSL verification which allows requests to sites
+using self-signed certificates, for example.
 
 ==============================================================================
 Installation                                          *http-client-installation*

--- a/plugin/http_client.py
+++ b/plugin/http_client.py
@@ -12,13 +12,14 @@ except NameError:
 if not from_cmdline:
     import vim
 
-
 METHOD_REGEX = re.compile('^(GET|POST|DELETE|PUT|HEAD|OPTIONS|PATCH) (.*)$')
 HEADER_REGEX = re.compile('^([^()<>@,;:\<>/\[\]?={}]+):\\s*(.*)$')
 VAR_REGEX = re.compile('^# ?(:[^: ]+)\\s*=\\s*(.+)$')
 GLOBAL_VAR_REGEX = re.compile('^# ?(\$[^$ ]+)\\s*=\\s*(.+)$')
 FILE_REGEX = re.compile("!((?:file)|(?:(?:content)))\((.+)\)")
 JSON_REGEX = re.compile("(javascript|json)$", re.IGNORECASE)
+
+verify_ssl = True if vim.eval('g:http_client_verify_ssl') == '1' else False
 
 
 def replace_vars(string, variables):
@@ -76,7 +77,11 @@ def do_request(block, buf):
       # Straight data: just send it off as a string.
       data = '\n'.join(data)
 
-    response = requests.request(method, url, headers=headers, data=data, files=files)
+    if not verify_ssl:
+        from requests.packages.urllib3.exceptions import InsecureRequestWarning
+        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+    response = requests.request(method, url, verify=verify_ssl, headers=headers, data=data, files=files)
     content_type = response.headers.get('Content-Type', '').split(';')[0]
 
     response_body = response.text

--- a/plugin/http_client.py
+++ b/plugin/http_client.py
@@ -19,7 +19,7 @@ GLOBAL_VAR_REGEX = re.compile('^# ?(\$[^$ ]+)\\s*=\\s*(.+)$')
 FILE_REGEX = re.compile("!((?:file)|(?:(?:content)))\((.+)\)")
 JSON_REGEX = re.compile("(javascript|json)$", re.IGNORECASE)
 
-verify_ssl = True if vim.eval('g:http_client_verify_ssl') == '1' else False
+verify_ssl = vim.eval('g:http_client_verify_ssl') == '1'
 
 
 def replace_vars(string, variables):

--- a/plugin/http_client.vim
+++ b/plugin/http_client.vim
@@ -21,6 +21,10 @@ if !exists('http_client_focus_output_window')
   let g:http_client_focus_output_window = 1
 endif
 
+if !exists('http_client_verify_ssl')
+  let g:http_client_verify_ssl = 1
+endif
+
 function! s:DoHTTPRequest()
   if !has('python')
     echo 'Error: this plugin requires vim compiled with python support.'


### PR DESCRIPTION
I use this plugin for development against APIs deployed on web servers with self-signed certificates. Currently, requests against these endpoints fail with an SSL error.

This change adds a configuration variable which will disable SSL verification for requests.

This also contains a fix for https://github.com/aquach/vim-http-client/issues/3.
