### PR TITLE
Add option to preserve responses in the output buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ By default the focus will go to the output window. If set to 0 the focus will re
 
 By default requests will verify SSL certificates for HTTPS endpoints. Setting this option to 0 disables SSL verification which allows requests to sites using self-signed certificates, for example.
 
+#### g:http_client_preserve_responses (default 0)
+
+By default responses will be written to the output buffer replacing any previous response. Setting this option to 1 will preserve previous responses, adding the latest response to the top of the buffer.  
+
 ## Contributing
 
 This plugin is currently quite simple. Contributions, suggestions, and feedback are all welcomed!

--- a/doc/http-client.txt
+++ b/doc/http-client.txt
@@ -93,7 +93,8 @@ Configuration                                        *http-client-configuration*
                                                          *g:http_client_json_ft*
                                                  *g:http_client_json_escape_utf*
                                                    *g:http_client_result_vsplit*
-                                                   *g:http_client_verify_ssl*
+                                                      *g:http_client_verify_ssl*
+                                              *g:http_client_preserve_responses*
 
 g:http_client_bind_hotkey (default 1)
 
@@ -128,6 +129,12 @@ g:http_client_verify_ssl (default 1)
 By default requests will verify SSL certificates for HTTPS endpoints. Setting
 this option to 0 disables SSL verification which allows requests to sites
 using self-signed certificates, for example.
+
+g:http_client_preserve_responses (default 0)
+
+By default responses will be written to the output buffer replacing any
+previous response. Setting this option to 1 will preserve previous responses, 
+adding the latest response to the top of the buffer. 
 
 ==============================================================================
 Installation                                          *http-client-installation*

--- a/plugin/http_client.py
+++ b/plugin/http_client.py
@@ -145,7 +145,7 @@ def open_scratch_buffer(contents, filetype):
         vim.command('%swincmd w' % existing_buffer_window_id)
 
     vim.command('set filetype=%s' % filetype)
-    vim.current.buffer[:] = contents
+    write_content(contents, vim.current.buffer)
 
     if vim.eval('g:http_client_focus_output_window') != '1':
         vim.current.window = previous_window
@@ -161,6 +161,15 @@ def do_request_from_buffer():
         vim_ft = vim_filetypes_by_content_type().get(content_type, 'text')
         open_scratch_buffer(response, vim_ft)
 
+
+def write_content(content, buffer):
+    if vim.eval('g:http_client_preserve_responses') == '1':
+        if len(buffer):
+            buffer[0:0] = [""]
+        buffer[0:0] = content
+        vim.command('0')
+    else:
+        buffer[:] = content
 
 # Tests.
 

--- a/plugin/http_client.py
+++ b/plugin/http_client.py
@@ -145,7 +145,7 @@ def open_scratch_buffer(contents, filetype):
         vim.command('%swincmd w' % existing_buffer_window_id)
 
     vim.command('set filetype=%s' % filetype)
-    write_content(contents, vim.current.buffer)
+    write_buffer(contents, vim.current.buffer)
 
     if vim.eval('g:http_client_focus_output_window') != '1':
         vim.current.window = previous_window
@@ -162,14 +162,14 @@ def do_request_from_buffer():
         open_scratch_buffer(response, vim_ft)
 
 
-def write_content(content, buffer):
+def write_buffer(contents, buffer):
     if vim.eval('g:http_client_preserve_responses') == '1':
         if len(buffer):
             buffer[0:0] = [""]
-        buffer[0:0] = content
+        buffer[0:0] = contents
         vim.command('0')
     else:
-        buffer[:] = content
+        buffer[:] = contents
 
 # Tests.
 

--- a/plugin/http_client.vim
+++ b/plugin/http_client.vim
@@ -25,6 +25,10 @@ if !exists('http_client_verify_ssl')
   let g:http_client_verify_ssl = 1
 endif
 
+if !exists('http_client_preserve_responses')
+  let g:http_client_preserve_responses = 0
+endif
+
 function! s:DoHTTPRequest()
   if !has('python')
     echo 'Error: this plugin requires vim compiled with python support.'


### PR DESCRIPTION
This provides an option to preserve responses in the same buffer; I've found this useful when I need to make several API requests in succession and want to compare the output.
