### PR TITLE
Ability to resolve variables with file data

### DIFF
--- a/plugin/http_client.py
+++ b/plugin/http_client.py
@@ -44,7 +44,10 @@ def do_request(block, buf):
       except IOError:
          raise ValueError('File: %s not found' % arg)
 
-    variables.update(dict([(k, to_file(v).read().strip("\n\r\t")) for (k, v) in variables.items() if FILE_REGEX.match(v)]))
+    try:
+      variables.update(dict([(k, to_file(v).read().strip("\n\r\t")) for (k, v) in variables.items() if FILE_REGEX.match(v)]))
+    except ValueError as err:
+        print(err)
 
     block = [line for line in block if not is_comment(line) and line.strip() != '']
 


### PR DESCRIPTION
This PR will resolve variables declared with `!file(SomeValidFile)` with contents of the file.
The Contents of $fileData will hold String data instead of file pointer.
eg: # $fileData = !file(SomeValidFile)

I wanted to switch between users with multiple cookies. Since, having a big :cookie:, switching between users was painful.
This changes will help to copy data from file, and use it in Headers as well as any other segment.

### Input File 
```
# Define Cookies
# $JohnCookie = !file(/tmp/JohnCookie)
# $MyCookie = !file(/tmp/MyCookie)
#
# Set User
# $globalCookie = $MyCookie
POST http://httpbin.org/post
Cookie: $globalCookie
SomeData

# Run 2 Using POST Data 
POST http://httpbin.org/post
Cookie: $globalCookie
$globalCookie
```


### Output

```
{
  "args": {},
  "data": "MyCookie",
  "files": {},
  "form": {},
  "headers": {
    "Accept": "*/*",
    "Accept-Encoding": "gzip, deflate",
    "Content-Length": "8",
    "Cookie": "MyCookie",
    "Host": "httpbin.org",
    "User-Agent": "python-requests/2.13.0"
  },
  "json": null,
  "origin": "XXX",
  "url": "http://httpbin.org/post"
}

// status code: 200
// Server: nginx
// Date: Tue, 31 Jan 2017 18:48:41 GMT
// Content-Type: application/json
// Content-Length: 365
// Connection: keep-alive
// Access-Control-Allow-Origin: *
// Access-Control-Allow-Credentials: true
```

### Error Handling 

#### when file is incorrect or missing:
Prints at bottom on `vi`
```
 File: /MyCookie not found
```